### PR TITLE
[UM-11] refactor event types colors

### DIFF
--- a/app/forms/event_form/create_event.rb
+++ b/app/forms/event_form/create_event.rb
@@ -35,7 +35,10 @@ module EventForm
     def send_notification
       return true if resource.event_type.slack_webhook.blank?
 
-      Slack::SendNotification.call(resource.event_type.slack_webhook) do |msg|
+      Slack::SendNotification.call(
+        resource.event_type.slack_webhook,
+        resource.event_type.color_or_default
+      ) do |msg|
         assign_notification_data(msg)
         assign_notification_fields(msg)
         assign_notification_footer(msg)

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -15,11 +15,11 @@ module EventsHelper
     "(#{event.users_joined.count} + #{pluralize(event.friends_count, 'friend')})"
   end
 
-  def event_circle_style(event)
-    "background: #{event.event_type.color}"
+  def event_type_bg_color(event)
+    event.event_type.color.presence || EventType::DEFAULT_COLOR
   end
 
   def event_circle_icon(event)
-    event.event_type.icon.presence || Event::DEFAULT_ICON
+    event.event_type.icon.presence || EventType::DEFAULT_ICON
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,4 @@
 class Event < ApplicationRecord
-  DEFAULT_ICON = 'event-checkmark'.freeze
-
   scope :upcoming, -> { where('datetime > ?', Time.zone.now).order(:datetime) }
   scope :of_event_type_id, ->(param) { where(event_type_id: param) }
 

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -1,3 +1,10 @@
 class EventType < ApplicationRecord
+  DEFAULT_ICON = 'event-checkmark'.freeze
+  DEFAULT_COLOR = '#8e8e8e'.freeze
+
   has_many :events, dependent: :nullify
+
+  def color_or_default
+    color.presence || DEFAULT_COLOR
+  end
 end

--- a/app/services/slack/send_notification.rb
+++ b/app/services/slack/send_notification.rb
@@ -3,25 +3,12 @@ module Slack
     # this sends notification using slack webhook API
     # learn how to build notifications: https://api.slack.com/docs/messages
 
-    DEFAULT_COLOR = :blue
-
-    COLORS = {
-      red: '#c60000',
-      green: '#36a64f',
-      blue: '#00a1ff',
-      yellow: '#e5ca44',
-      gray: '#8e8e8e'
-    }.freeze
-
-    def self.call(webhook, color = DEFAULT_COLOR)
+    def self.call(webhook, color = EventType::DEFAULT_COLOR)
       raise Umawianko::RuntimeError, 'Slack webhook is required' if webhook.blank?
-      raise Umawianko::RuntimeError, "Invalid color #{color}" if COLORS[color].blank?
 
       message = ActiveSupport::OrderedOptions.new.tap do |msg|
         msg.fallback = 'Notification.'
-        msg.color = COLORS[color]
-        msg.title = ''
-        msg.text = ''
+        msg.color = color
         msg.fields = [] # title, value, short
       end
 

--- a/app/views/event/_card.html.erb
+++ b/app/views/event/_card.html.erb
@@ -3,7 +3,7 @@
     <div class='event-card__date m-m--r'>
       <%= format_event_date(event) %>
     </div>
-    <div class='event-card__circle' style="<%= event_circle_style(event) %>">
+    <div class='event-card__circle' style="background: <%= event_type_bg_color(event) %>">
       <span class="umi umi--<%= event_circle_icon(event) %>"></span>
     </div>
   </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -9,7 +9,7 @@
           @event.event_type.name,
           events_path(event_type_id: @event.event_type_id),
           class: 'm-m--l event-heading__badge',
-          style: event_circle_style(@event)
+          style: "background: #{event_type_bg_color(@event)}"
         ) %>
       </div>
     </div>

--- a/spec/features/add_event_spec.rb
+++ b/spec/features/add_event_spec.rb
@@ -63,7 +63,8 @@ describe 'add event', type: :feature do
           click_button 'Submit'
 
           expect(Slack::SendNotification).to have_received(:call).once.with(
-            'https://foo.com/webhook'
+            'https://foo.com/webhook',
+            '#aaa'
           )
         end
       end

--- a/spec/forms/event_form/create_event_spec.rb
+++ b/spec/forms/event_form/create_event_spec.rb
@@ -21,7 +21,7 @@ describe EventForm::CreateEvent, type: :form do
           form.save
 
           expect(Slack::SendNotification).to have_received(:call)
-            .once.with('http://example.com/webhook')
+            .once.with('http://example.com/webhook', '#aaa')
         end
       end
 

--- a/spec/services/slack/send_notification_spec.rb
+++ b/spec/services/slack/send_notification_spec.rb
@@ -7,14 +7,6 @@ describe Slack::SendNotification do
     end
   end
 
-  context 'if provided color is invalid' do
-    it 'raises error' do
-      expect {
-        Slack::SendNotification.call('http://example.com/webhook', :invalid_color)
-      }.to raise_error(Umawianko::RuntimeError)
-    end
-  end
-
   context 'if provided data is valid' do
     it 'sends notification using slack-notifier gem' do
       notifier = instance_double(Slack::Notifier)
@@ -32,7 +24,7 @@ describe Slack::SendNotification do
       expect(notifier).to have_received(:post).with(
         attachments: include(
           fallback: 'Notification.',
-          color: '#00a1ff',
+          color: '#8e8e8e',
           title: 'Lorem ipsum',
           text: 'Dolor sit amet',
           fields: include(title: 'Foo', value: 'Bar', short: true),


### PR DESCRIPTION
This closes #11

## Overview
Remove predefined slack notification colors. Use custom event_type colors instead.

## Preview
![image](https://user-images.githubusercontent.com/9076315/45509017-a968df80-b796-11e8-8711-a41dfcfba491.png)
